### PR TITLE
Added disable option to main.py

### DIFF
--- a/code/main.py
+++ b/code/main.py
@@ -105,11 +105,20 @@ if __name__ == "__main__":
     module_conf_file, user_conf_file, log_level = handle_args()
     logging.basicConfig(level=log_level)
     conf = config_manager.get_config(module_conf_file, user_conf_file)
-    signal.signal(signal.SIGINT, graceful_signal_handler)
-    signal.signal(signal.SIGTERM, graceful_signal_handler)
-    signal.signal(signal.SIGALRM, harsh_signal_handler)
-    bbs = create_building_blocks(conf)
-    start_building_blocks(bbs)
-    monitor_building_blocks(bbs)
+
+    if conf.get("module_enabled", True):        # in case this feature is not used in any config files, start up anyway
+         
+        signal.signal(signal.SIGINT, graceful_signal_handler)
+        signal.signal(signal.SIGTERM, graceful_signal_handler)
+        signal.signal(signal.SIGALRM, harsh_signal_handler)
+    
+        bbs = create_building_blocks(conf)
+        start_building_blocks(bbs)
+        monitor_building_blocks(bbs)
+
+    else:
+        logger.info("Sensing module is disabled, sleeping for an hour before restarting")
+        time.sleep(3600)
 
     logger.info("Done")
+


### PR DESCRIPTION
As per #8, implement an option to disable the module at startup as seen in [Downtime #24](https://github.com/DigitalShoestringSolutions/DowntimeMonitoring/blob/85941452399856941ced44ef0239b2b75634cf25/sensing/code/main.py#L102-L122)

Default is module is enabled, i.e. config has to opt into disabling. 

There's no clear place to add the config snipped - I can't see any config files in this repo?
Should a how-to-use note go into `Writing a Config File`?
