### PR TITLE
Add read() and write() to spi.py

### DIFF
--- a/code/core/interface_modules/spi.py
+++ b/code/core/interface_modules/spi.py
@@ -17,3 +17,26 @@ class SPI:
         self.spi.mode = self.default_mode if mode is None else mode
         self.spi.max_speed_hz  = self.default_speed if speed is None else speed
         return self.spi.xfer2(bytes)
+
+    def read(self, reg: int, n_words: int=1, mode: int=None, speed_hz: int=None) -> list:
+        """Clocks `reg` into the SPI device, then clock out `n_words` more words.
+
+        :param int reg:     The register to be clocked into the device before reading.
+        :param int n_words: (optional) The number of words to read. Default 1.
+        :param int mode:    (optional) Change the bus config before the transaction. `(clock polarity << 1 | clock phase)` as a 2 bit int.
+        :param int speed:   (optional) Change the bus config before the transaction. Set SPI clock speed in Hz.
+        :return:            list of integers        
+        """
+        return self.transfer([reg] + [0]*n_words, mode=mode, speed=speed_hz)[1:] # The first word returned is discarded, as it was while the reg was being clocked in.
+
+    def write(self, reg: int, data, mode: int=None, speed_hz: int=None) -> None:
+        """Write `reg` to the SPI device, then write `data` to the SPI device. `data` can be an int for a single word, or a list of ints for multiple words.
+
+        :param int reg:   The register to be clocked into the device before writing `data`.
+        :param data:      The words to be written after reg. Single int or list of ints.
+        :param int mode:  (optional) Change the bus config before the transaction. `(clock polarity << 1 | clock phase)` as a 2 bit int.
+        :param int speed: (optional) Change the bus config before the transaction. Set SPI clock speed in Hz.
+        """
+        if isinstance(data, int):
+            data = [data]
+        self.transfer([reg] + data, mode=mode, speed=speed_hz)


### PR DESCRIPTION
`xfer2()` is a wonderfully powerful all-purpose SPI function. But it is not the most user-friendly.

When writing for a SPI device I often find myself adding something like:
```
def _read_regs(reg, nbytes):
    return self.spi.xfer2([reg] + [0]*bytes)[1:]
```
We could include that in every device module that uses `interface_modules/spi.py`, or we could provide it in the interface itself?

Here I propose adding two convenience wrappers to transfer() for easy access to device memory. 