### PR TITLE
Make mqtt reconnect config optional

### DIFF
--- a/code/mqtt_out.py
+++ b/code/mqtt_out.py
@@ -29,9 +29,10 @@ class MQTTServiceWrapper(multiprocessing.Process):
 
         self.topic_base = mqtt_conf.get('topic_prefix',"")
 
-        self.initial = mqtt_conf['reconnect'].get('initial',5)
-        self.backoff = mqtt_conf['reconnect'].get('backoff',2)
-        self.limit = mqtt_conf['reconnect'].get('limit',60)
+        mqtt_conf_reconnect = mqtt_conf.get('reconnect', {})
+        self.initial = mqtt_conf_reconnect.get('initial', 5)
+        self.backoff = mqtt_conf_reconnect.get('backoff', 2)
+        self.limit = mqtt_conf_reconnect.get('limit', 60)
 
         # declarations
         self.zmq_conf = zmq_conf
@@ -99,3 +100,4 @@ class MQTTServiceWrapper(multiprocessing.Process):
                     pass
             client.loop(0.05)
         logger.info("Done")
+


### PR DESCRIPTION
Currently, most module config files end in:
```toml
[mqtt]
    broker = "mqtt.docker.local"
    port = 1883   #common mqtt ports are 1883 and 8883
    topic_prefix = ""

    #reconnection characteristics
    # start: timeout = initial,
    # if timeout < limit then
    #   timeout = timeout*backoff
    # else
    #   timeout = limit
    reconnect.initial = 5 # seconds
    reconnect.backoff = 2 # multiplier
    reconnect.limit = 60 # seconds
```

Given that `mqtt_out.py` has default values for `initial`, `backoff` and `limit`:
```
self.initial = mqtt_conf['reconnect'].get('initial',5)
self.backoff = mqtt_conf['reconnect'].get('backoff',2)
self.limit = mqtt_conf['reconnect'].get('limit',60)
```
It would be nice if they could be used and the `reconnect.x` section omitted from the config file.
Attempt this currently and this raises a `KeyError: 'reconnect'` due to the `get` being after the `['reconnect']`.
This makes it optional.

Consider also making `broker` default to `mqtt.docker.local` and `port` to `1883`? And then making the whole `mqtt` section of the config optional? 
