### PR TITLE
Add optional delay during I2C reads

### DIFF
--- a/code/core/interface_modules/i2c.py
+++ b/code/core/interface_modules/i2c.py
@@ -1,6 +1,7 @@
 from smbus2 import SMBus
 from smbus2 import i2c_msg as Msg
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -16,12 +17,23 @@ class I2C:
     def initialise(self):
         self.i2c.open(self.bus)
 
-    def read_register(self,address,register,num_bytes,stop=False):     # Write address, register_no  -- Read address, data
+    def read_register(self,address,register,num_bytes,stop=False, delay:float=None):     # Write address, register_no  -- Read address, data
+        """Read a number of registers from attached I2C device.
+
+        :param int address:   I2C slave device address
+        :param int register:  Memory register to read first data byte from
+        :param int num_bytes: Number of sequential bytes to read
+        :paran bool stop:     (optional) If false, complete the reg write and data read in a single transaction 
+        :param float delay:   (optional) Seconds to sleep for between writing register and reading back data. Requires `stop=True` to be effective.
+        """
+        
         write_reg_addr = Msg.write(address,[register])
         read_reg_data = Msg.read(address,num_bytes)
 
         if stop:
             self.i2c.i2c_rdwr(write_reg_addr)
+            if delay:
+                time.sleep(delay)
             self.i2c.i2c_rdwr(read_reg_data)
         else:
             self.i2c.i2c_rdwr(write_reg_addr, read_reg_data)
@@ -30,4 +42,5 @@ class I2C:
 
     def write_register(self,address,register,data):    #Write address, register, data...
         write_reg_addr_data = Msg.write(address,[register,*data])
+
         self.i2c.i2c_rdwr(write_reg_addr_data)

--- a/code/core/interface_modules/i2c.py
+++ b/code/core/interface_modules/i2c.py
@@ -20,13 +20,13 @@ class I2C:
     def read_register(self,address,register,num_bytes,stop=False, delay:float=None):     # Write address, register_no  -- Read address, data
         """Read a number of registers from attached I2C device.
 
-        :param int address:   I2C slave device address
-        :param int register:  Memory register to read first data byte from
-        :param int num_bytes: Number of sequential bytes to read
-        :paran bool stop:     (optional) If false, complete the reg write and data read in a single transaction 
+        :param int address:   I2C slave device address.
+        :param int register:  Memory register to read first data byte from.
+        :param int num_bytes: Number of sequential bytes to read.
+        :paran bool stop:     (optional) If false, complete the reg write and data read in a single transaction.
         :param float delay:   (optional) Seconds to sleep for between writing register and reading back data. Requires `stop=True` to be effective.
         """
-        
+
         write_reg_addr = Msg.write(address,[register])
         read_reg_data = Msg.read(address,num_bytes)
 
@@ -42,5 +42,4 @@ class I2C:
 
     def write_register(self,address,register,data):    #Write address, register, data...
         write_reg_addr_data = Msg.write(address,[register,*data])
-
         self.i2c.i2c_rdwr(write_reg_addr_data)


### PR DESCRIPTION
Port over the changes [seen in Humidity Monitoring ](https://github.com/DigitalShoestringSolutions/HumidityMonitoring/blob/99898ab9aa994465d8e52c66d5d4a0437653ed9e/humidity_sensing/code/core/interface_modules/i2c.py) that allow a stop condition, sleep, a start condition on the I2C bus between writing the memory to read from and clocking the data back. 

Required for some sensors e.g. BMP280. 

Free docstring while I'm there. 